### PR TITLE
Add support for Rock 5B+ across multiple OS configurations

### DIFF
--- a/docs/android/index.json
+++ b/docs/android/index.json
@@ -17,14 +17,42 @@
           {
             "name": "Android 12 (Rock 5B)",
             "description": "Radxa Android 12 build",
-            "url": "https://github.com/radxa/manifests/releases/download/Rock-android12-20230315/Rock5B-Android12-rkr12-20230315-gpt.zip",
+            "url": "https://github.com/radxa/manifests/releases/download/Android12_rkr14_20240419/Rock5B_Android12_rkr14_20240419-gpt.zip",
             "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/Android_robot_%282014-2019%29.svg/151px-Android_robot_%282014-2019%29.svg.png",
             "website": "https://docs.radxa.com/en/rock5/official-images?model=ROCK+5B",
             "extract_size": 409600000,
             "image_download_size": 789000000,
-            "release_date": "2023-03-14",
+            "release_date": "2024-04-19",
             "devices": [
               "rock-5b"
+            ],
+            "init_format": "none"
+          },
+          {
+            "name": "Android 12 (Rock 5B+) sdcard/emmc",
+            "description": "Radxa Android 12 build",
+            "url": "https://github.com/radxa/manifests/releases/download/android12-radxa-20240708/Rock5BPlus-Android12-rkr14-SD-or-eMMC-20240705-1-gpt.zip",
+            "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/Android_robot_%282014-2019%29.svg/151px-Android_robot_%282014-2019%29.svg.png",
+            "website": "https://docs.radxa.com/en/rock5/rock5b/download",
+            "extract_size": 409600000,
+            "image_download_size": 868054720,
+            "release_date": "2024-07-08",
+            "devices": [
+              "rock-5b-plus"
+            ],
+            "init_format": "none"
+          },
+          {
+            "name": "Android 12 (Rock 5B+) NVME only",
+            "description": "Radxa Android 12 build",
+            "url": "https://github.com/radxa/manifests/releases/download/android12-radxa-20240708/Rock5BPlus-Android12-rkr14-SPI_NVME-20240705-update.zip",
+            "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/Android_robot_%282014-2019%29.svg/151px-Android_robot_%282014-2019%29.svg.png",
+            "website": "https://docs.radxa.com/en/rock5/rock5b/download",
+            "extract_size": 409600000,
+            "image_download_size": 1646299773,
+            "release_date": "2024-07-08",
+            "devices": [
+              "rock-5b-plus"
             ],
             "init_format": "none"
           }

--- a/docs/archlinux-installer/index.json
+++ b/docs/archlinux-installer/index.json
@@ -29,6 +29,20 @@
             "init_format": "none"
           },
           {
+            "name": "Arch Linux Installer for Rock 5B+",
+            "description": "Community-built Arch Linux Installer for ARM (Aarch64)",
+            "url": "https://github.com/kwankiu/archlinux-installer/releases/download/b08/radxa-rock-5b-plus-archlinux-installer.img.xz",
+            "icon": "https://avatars.githubusercontent.com/u/52997?s=280&v=4",
+            "website": "https://github.com/kwankiu/archlinux-installer/wiki",
+            "extract_size": 5746553856,
+            "image_download_size": 354810776,
+            "release_date": "2024-08-20",
+            "devices": [
+              "rock-5b-plus"
+            ],
+            "init_format": "none"
+          },
+          {
             "name": "Arch Linux Installer for Rock 5A (development build)",
             "description": "Community-built Arch Linux Installer for ARM (Aarch64)",
             "url": "https://github.com/kwankiu/archlinux-installer/releases/download/b08-dev/radxa-rock-5a-archlinux-installer.img.xz",

--- a/docs/armbian/index.json
+++ b/docs/armbian/index.json
@@ -1,6 +1,6 @@
 {
     "os_list": [
-        {
+          {
             "name": "Armbian Debian Bookworm",
             "description": "Armbian is a computing build framework that allows users to create ready-to-use images with working kernels in variable user space configurations for various single board computers. It provides various pre-build images for some supported boards. These are usually Debian or Ubuntu flavored.",
             "url": "https://xogium.performanceservers.nl/archive/rock-5a/archive/Armbian_23.11.1_Rock-5a_bookworm_edge_6.7.0-rc1.img.xz",
@@ -43,6 +43,34 @@
             "init_format": "none"
           },
           {
+            "name": "Armbian Debian Bookworm (Cinnamon)",
+            "description": "Armbian is a computing build framework that allows users to create ready-to-use images with working kernels in variable user space configurations for various single board computers. It provides various pre-build images for some supported boards. These are usually Debian or Ubuntu flavored.",
+            "url": "https://dl.armbian.com/rock-5b-plus/Bookworm_vendor_cinnamon-backported-mesa",
+            "icon": "https://i.ibb.co/Cnf2LW4/de88b5d6324f3fa7631368880363494a0faa601b.png",
+            "website": "https://www.armbian.com/rock-5b-plus/",
+            "extract_size": 409600000,
+            "image_download_size": 1270000000,
+            "release_date": "2025-02-26",
+            "devices": [
+              "rock-5b-plus"
+            ],
+            "init_format": "none"
+          },
+          {
+            "name": "Armbian Debian Bookworm (XFCE)",
+            "description": "Armbian is a computing build framework that allows users to create ready-to-use images with working kernels in variable user space configurations for various single board computers. It provides various pre-build images for some supported boards. These are usually Debian or Ubuntu flavored.",
+            "url": "https://dl.armbian.com/rock-5b-plus/Bookworm_vendor_xfce",
+            "icon": "https://i.ibb.co/Cnf2LW4/de88b5d6324f3fa7631368880363494a0faa601b.png",
+            "website": "https://www.armbian.com/rock-5b-plus/",
+            "extract_size": 409600000,
+            "image_download_size": 1270000000,
+            "release_date": "2025-02-26",
+            "devices": [
+              "rock-5b-plus"
+            ],
+            "init_format": "none"
+          },
+          {
             "name": "Armbian Ubuntu Jammy",
             "description": "Armbian is a computing build framework that allows users to create ready-to-use images with working kernels in variable user space configurations for various single board computers. It provides various pre-build images for some supported boards. These are usually Debian or Ubuntu flavored.",
             "url": "https://github.com/armbian/community/releases/download/24.5.0-trunk.19/Armbian_community_24.5.0-trunk.19_Rock-5b_jammy_edge_6.8.0-rc1_gnome_desktop.img.xz",
@@ -53,6 +81,48 @@
             "release_date": "2024-01-01",
             "devices": [
               "rock-5b"
+            ],
+            "init_format": "none"
+          },
+          {
+            "name": "Armbian Ubuntu Jammy (XFCE)",
+            "description": "Armbian is a computing build framework that allows users to create ready-to-use images with working kernels in variable user space configurations for various single board computers. It provides various pre-build images for some supported boards. These are usually Debian or Ubuntu flavored.",
+            "url": "https://dl.armbian.com/rock-5b-plus/Noble_vendor_xfce",
+            "icon": "https://i.ibb.co/Cnf2LW4/de88b5d6324f3fa7631368880363494a0faa601b.png",
+            "website": "https://www.armbian.com/rock-5b-plus/",
+            "extract_size": 409600000,
+            "image_download_size": 1270000000,
+            "release_date": "2025-02-26",
+            "devices": [
+              "rock-5b-plus"
+            ],
+            "init_format": "none"
+          },
+          {
+            "name": "Armbian Ubuntu Jammy (Gnome)",
+            "description": "Armbian is a computing build framework that allows users to create ready-to-use images with working kernels in variable user space configurations for various single board computers. It provides various pre-build images for some supported boards. These are usually Debian or Ubuntu flavored.",
+            "url": "https://dl.armbian.com/rock-5b-plus/Noble_vendor_gnome",
+            "icon": "https://i.ibb.co/Cnf2LW4/de88b5d6324f3fa7631368880363494a0faa601b.png",
+            "website": "https://www.armbian.com/rock-5b-plus/",
+            "extract_size": 409600000,
+            "image_download_size": 1270000000,
+            "release_date": "2025-02-26",
+            "devices": [
+              "rock-5b-plus"
+            ],
+            "init_format": "none"
+          },
+          {
+            "name": "Armbian Debian Bookworm (Home Assistant)",
+            "description": "Home Assistant OS – Based on Armbian and Debian for seamless smart home automation.",
+            "url": "https://dl.armbian.com/rock-5b-plus/Bookworm_current_minimal-homeassistant",
+            "icon": "https://avatars.githubusercontent.com/u/13844975?s=200&v=4",
+            "website": "https://www.armbian.com/rock-5b-plus/",
+            "extract_size": 409600000,
+            "image_download_size": 1270000000,
+            "release_date": "2025-02-26",
+            "devices": [
+              "rock-5b-plus"
             ],
             "init_format": "none"
           }

--- a/docs/bred-os/index.json
+++ b/docs/bred-os/index.json
@@ -27,6 +27,20 @@
               "rock-5b"
             ],
             "init_format": "none"
+          },
+          {
+            "name": "BredOS Archlinux Rock 5B+",
+            "description": "Get a buttery-smooth experience with BredOS!",
+            "url": "https://github.com/BredOS/images/releases/download/2025-01-08/BredOS-ARM-Rock5B-Plus-2025-01-08.img.xz",
+            "icon": "https://bredos.org/assets/img/bredlogo.png",
+            "website": "https://bredos.org",
+            "extract_size": 5027057664,
+            "image_download_size": 1065489156,
+            "release_date": "2025-01-08",
+            "devices": [
+              "rock-5b-plus"
+            ],
+            "init_format": "none"
           }
     ]
   }

--- a/docs/index.json
+++ b/docs/index.json
@@ -29,6 +29,16 @@
         "matching_type": "inclusive"
       },
       {
+        "name": "Radxa ROCK 5B Plus",
+        "tags": [
+          "rock-5b-plus"
+        ],
+        "default": false,
+        "icon": "https://radxa.com/rock5/rock_5b+/banner_rock5bp.webp",
+        "description": "New Upgrade Version of ROCK 5B",
+        "matching_type": "inclusive"
+      },
+      {
         "name": "Radxa ROCK 5C",
         "tags": [
           "rock-5c"
@@ -154,6 +164,12 @@
           "description": "openFyde is an open-source initiative started by Fyde Innovations, the creator of FydeOS, with an aim to provide another approach to Chromium OS. With openFyde, you can have a more open and flexible Chromium OS. In comparison, FydeOS offers a more stable experience, better performance, and unique features.",
           "icon": "https://avatars.githubusercontent.com/u/88576843?s=200&v=4",
           "subitems_url": "https://rock5-images-repo.github.io/openfyde/index.json"
+        },
+        {
+          "name": "UEFI",
+          "description": "The Unified Extensible Firmware Interface (UEFI) is a specification for a software program that connects a computer's firmware to its operating system (OS).UEFI is expected to eventually replace the Basic Input/Output System (BIOS), but is compatible with it.",
+          "icon": "https://docs.radxa.com/img/rock5b/downloads/UFEI.webp",
+          "subitems_url": "https://rock5-images-repo.github.io/uefi/index.json"
         },
         {
           "name": "Windows on R",

--- a/docs/joshua-riek-ubuntu/index.json
+++ b/docs/joshua-riek-ubuntu/index.json
@@ -28,6 +28,34 @@
               "rock-5b"
             ],
             "init_format": "none"
+          },
+          {
+            "name": "Spooky Hooky Joshua's Riek Ubuntu 22.04",
+            "description": "A very well aclaimed version of ubuntu for our wee boards? Hell yeah!!",
+            "url": "https://github.com/Joshua-Riek/ubuntu-rockchip/releases/download/v2.4.0/ubuntu-22.04-preinstalled-desktop-arm64-rock-5b-plus.img.xz",
+            "icon": "https://forum.radxa.com/uploads/default/original/2X/d/d7daedb88b9eb8817eab5662eb0e435dc0cc7820.jpeg",
+            "website": "https://joshua-riek.github.io/ubuntu-rockchip-download/",
+            "extract_size": 409600000,
+            "image_download_size": 1270000000,
+            "release_date": "2024-10-23",
+            "devices": [
+              "rock-5b-plus"
+            ],
+            "init_format": "none"
+          },
+          {
+            "name": "Spooky Hooky Joshua's Riek Ubuntu 24.04",
+            "description": "A very well aclaimed version of ubuntu for our wee boards? Hell yeah!!",
+            "url": "https://github.com/Joshua-Riek/ubuntu-rockchip/releases/download/v2.4.0/ubuntu-24.04-preinstalled-desktop-arm64-rock-5b-plus.img.xz",
+            "icon": "https://forum.radxa.com/uploads/default/original/2X/d/d7daedb88b9eb8817eab5662eb0e435dc0cc7820.jpeg",
+            "website": "https://joshua-riek.github.io/ubuntu-rockchip-download/",
+            "extract_size": 409600000,
+            "image_download_size": 1270000000,
+            "release_date": "2024-10-23",
+            "devices": [
+              "rock-5b-plus"
+            ],
+            "init_format": "none"
           }
     ]
   }

--- a/docs/radxa-os/index.json
+++ b/docs/radxa-os/index.json
@@ -153,6 +153,20 @@
               "rock-5b"
             ],
             "init_format": "none"
+          },
+          {
+            "name": "Radxa OS (ROCK 5B+ Debian Bookworm KDE)",
+            "description": "Radxa OS is the official operating system developed by Radxa based on Debian",
+            "url": "https://github.com/radxa-build/rock-5b-plus/releases/download/rsdk-b2/rock-5b-plus_bookworm_kde_b2.output.img.xz",
+            "icon": "https://docs.radxa.com/en/logo.svg",
+            "website": "https://docs.radxa.com/en/rock5/rock5b/download",
+            "extract_size": 409600000,
+            "image_download_size": 1280000000,
+            "release_date": "2024-08-08",
+            "devices": [
+              "rock-5b-plus"
+            ],
+            "init_format": "none"
           }
     ]
   }

--- a/docs/uefi/index.json
+++ b/docs/uefi/index.json
@@ -1,0 +1,32 @@
+{
+    "os_list": [
+            {
+            "name": "UEFI for Rock 5B+",
+            "description": "The Unified Extensible Firmware Interface (UEFI) is a specification for a software program that connects a computer's firmware to its operating system (OS).UEFI is expected to eventually replace the Basic Input/Output System (BIOS), but is compatible with it.",
+            "url": "https://github.com/edk2-porting/edk2-rk3588/releases/download/v0.12.2/rock-5b_UEFI_Release_v0.12.2.img",
+            "icon": "https://docs.radxa.com/img/rock5b/downloads/UFEI.webp",
+            "website": "https://github.com/edk2-porting/edk2-rk3588",
+            "extract_size": 409600000,
+            "image_download_size": 1270000000,
+            "release_date": "2025-01-05",
+            "devices": [
+                "rock-5b"
+            ],
+            "init_format": "none"
+            },
+            {
+            "name": "UEFI for Rock 5B+",
+            "description": "The Unified Extensible Firmware Interface (UEFI) is a specification for a software program that connects a computer's firmware to its operating system (OS).UEFI is expected to eventually replace the Basic Input/Output System (BIOS), but is compatible with it.",
+            "url": "https://github.com/edk2-porting/edk2-rk3588/releases/download/v0.12.2/rock-5bplus_UEFI_Release_v0.12.2.img",
+            "icon": "https://docs.radxa.com/img/rock5b/downloads/UFEI.webp",
+            "website": "https://github.com/edk2-porting/edk2-rk3588",
+            "extract_size": 409600000,
+            "image_download_size": 1270000000,
+            "release_date": "2025-01-05",
+            "devices": [
+                "rock-5b-plus"
+            ],
+            "init_format": "none"
+            }
+        ]
+}

--- a/docs/worproject/index.json
+++ b/docs/worproject/index.json
@@ -10,7 +10,7 @@
             "image_download_size": 1270000000,
             "release_date": "2024-01-01",
             "devices": [
-              "rock-5b"
+              "rock-5b", "rock-5b-plus"
             ],
             "init_format": "none"
           }


### PR DESCRIPTION
# Add Support for Radxa Rock 5B+ and Update 5B Images

## Changes:
- Added support for **Radxa Rock 5B+**.
- Updated some images for **Radxa Rock 5B**.
- Added **UEFI image** support.

## Notes:
This update improves compatibility and enhances functionality for Rock 5 series devices.

## Testing:
- Verified compatibility with **Rock 5B+** hardware.
- Ensured updated **5B images** function as expected.
- Confirmed **UEFI image** boots correctly.

Let me know if any modifications are needed! 🚀
